### PR TITLE
Commenting pass — add file-level headers to all three scripts

### DIFF
--- a/scripts/compendium-populator.js
+++ b/scripts/compendium-populator.js
@@ -1,3 +1,21 @@
+/**
+ * compendium-populator.js — Greenbottle's Hacking Quips
+ *
+ * Populates the module's compendium packs on first load (GM only).
+ * Each pack is checked — if it already has entries, it's skipped (idempotent).
+ *
+ * Packs populated:
+ *   knives-daggers-table — RollTable built from data/knives_and_daggers.json
+ *                          Each result stores knife details as flags for the macro to read.
+ *   trees-table          — RollTable built from data/trees.json
+ *   corals-table         — RollTable built from data/coral.json
+ *   macros               — Creates the "Roll Random Knife/Dagger" macro
+ *
+ * The _populateIfEmpty helper: unlocks the pack, runs the create function, re-locks it.
+ * This pattern prevents accidental edits to compendium content during normal play.
+ *
+ * Called from: hacking-quips.js on the 'ready' hook.
+ */
 export class CompendiumPopulator {
   static MODULE_ID = 'greenbottles-hacking-quips';
 

--- a/scripts/hacking-quips.js
+++ b/scripts/hacking-quips.js
@@ -1,3 +1,30 @@
+/**
+ * hacking-quips.js — Greenbottle's Hacking Quips
+ *
+ * Main module class (HackingQuips). Handles three distinct features:
+ *
+ *   1. HACKING QUIPS — Watches every chat message for Computers skill checks (SF2e hacking).
+ *      - If the roll has a DC set and it's a failure/critical failure: adds a "Show Hacking Quip"
+ *        button that posts a random flavour quip to chat when clicked.
+ *      - If there's no DC (GM rolls blind): adds GM adjudication buttons (Critical Success /
+ *        Success / Failure / Critical Failure). Selecting a failure result auto-posts a quip.
+ *      Button state (disabled vs removed after use) is controlled by a module setting.
+ *      Cross-client sync is handled via game.socket so all players see the same state.
+ *
+ *   2. TIMBER SENTINEL — A mini-feature that triggers whenever a chat message contains
+ *      "Timber Sentinel". Posts a random tree or coral species with flavour text.
+ *      Handled entirely by TimberSentinel (timber-sentinel-quips.js).
+ *
+ *   3. KNIVES & DAGGERS — Compendium roll tables and a macro for rolling random
+ *      knife/dagger entries with configurable detail fields.
+ *      Tables are populated on first load by CompendiumPopulator (compendium-populator.js).
+ *
+ * Socket actions handled:
+ *   removeControls / disableControls — sync adjudication button state across clients
+ *   removeButton / disableButton     — sync quip button state across clients
+ *   showQuip                         — broadcast the chosen quip to all relevant clients
+ */
+
 import { TimberSentinel } from './timber-sentinel-quips.js';
 import { CompendiumPopulator } from './compendium-populator.js';
 

--- a/scripts/timber-sentinel-quips.js
+++ b/scripts/timber-sentinel-quips.js
@@ -1,3 +1,23 @@
+/**
+ * timber-sentinel-quips.js — Greenbottle's Hacking Quips
+ *
+ * Handles the Timber Sentinel feature: when any chat message contains the text
+ * "Timber Sentinel", this class picks a random tree or coral species from its
+ * loaded JSON data and posts a flavoured chat message.
+ *
+ * Data sources (loaded at init from module's /data/ folder):
+ *   data/trees.json        — tree species with flavor text
+ *   data/coral.json        — coral species with scientific name, type, flavor, fun facts
+ *   data/custom-trees.json — optional GM-provided extra trees (merged in if present)
+ *   data/custom-coral.json — optional GM-provided extra corals (merged in if present)
+ *
+ * Display behaviour is controlled by several module settings (registered here):
+ *   timberSentinelEnableTrees / timberSentinelEnableCoral — toggle each pool on/off
+ *   timberSentinelSimple / Uppercase / Emphatic           — name formatting options
+ *   timberSentinelShowFlavor / ShowScientific / ShowCoralType / ShowFunFacts — coral detail toggles
+ *
+ * Used by: hacking-quips.js — called from onRenderChatMessage when TimberSentinel.check() returns true.
+ */
 export class TimberSentinel {
   static MODULE_ID = null;
 


### PR DESCRIPTION
## Summary
- \`hacking-quips.js\`: full header covering all three features (hacking quips, timber sentinel, knives & daggers) and socket actions
- \`timber-sentinel-quips.js\`: header explaining data sources and all configurable settings
- \`compendium-populator.js\`: header explaining which packs get populated and the lock/unlock pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)